### PR TITLE
Hide input for posts on own profile page #3

### DIFF
--- a/Smart Village App/views/content/widgets/wallCreateContentForm.php
+++ b/Smart Village App/views/content/widgets/wallCreateContentForm.php
@@ -1,0 +1,129 @@
+<?php
+
+use humhub\modules\topic\widgets\TopicPicker;
+use humhub\modules\ui\icon\widgets\Icon;
+use yii\helpers\Html;
+use humhub\modules\content\assets\ContentFormAsset;
+use humhub\modules\file\widgets\FilePreview;
+use humhub\modules\space\models\Space;
+use humhub\modules\user\widgets\UserPickerField;
+use humhub\modules\file\widgets\UploadButton;
+use humhub\modules\file\widgets\FileHandlerButtonDropdown;
+use humhub\modules\file\widgets\UploadProgress;
+use humhub\widgets\Link;
+use humhub\widgets\Button;
+
+/* @var $defaultVisibility integer */
+/* @var $submitUrl string */
+/* @var $form string */
+/* @var $submitButtonText string */
+/* @var $fileHandlers \humhub\modules\file\handler\BaseFileHandler[] */
+/* @var $canSwitchVisibility boolean */
+/* @var $contentContainer \humhub\modules\content\components\ContentContainerActiveRecord */
+
+ContentFormAsset::register($this);
+
+$this->registerJsConfig('content.form', [
+    'defaultVisibility' => $defaultVisibility,
+    'disabled' => ($contentContainer instanceof Space && $contentContainer->isArchived()),
+    'text' => [
+        'makePrivate' => Yii::t('ContentModule.base', 'Change to "Private"'),
+        'makePublic' => Yii::t('ContentModule.base', 'Change to "Public"'),
+        'info.archived' => Yii::t('ContentModule.base', 'This space is archived.')
+    ]]);
+
+$pickerUrl = ($contentContainer instanceof Space) ? $contentContainer->createUrl('/space/membership/search') : null;
+
+?>
+
+<div class="panel panel-default clearfix" style="display:none;">
+    <div class="panel-body" id="contentFormBody" style="display:none;" data-action-component="content.form.CreateForm" >
+        <?= Html::beginForm($submitUrl, 'POST'); ?>
+
+        <?= $form; ?>
+
+        <div id="notifyUserContainer" class="form-group" style="margin-top: 15px;display:none;">
+            <?= UserPickerField::widget([
+                'id' => 'notifyUserInput',
+                'url' => $pickerUrl,
+                'formName' => 'notifyUserInput',
+                'maxSelection' => 10,
+                'disabledItems' => [Yii::$app->user->guid],
+                'placeholder' => Yii::t('ContentModule.base', 'Add a member to notify'),
+            ]) ?>
+        </div>
+
+        <div id="postTopicContainer" class="form-group" style="margin-top: 15px;display:none;">
+            <?= TopicPicker::widget([
+                'id' => 'postTopicInput',
+                'name' => 'postTopicInput',
+                'contentContainer' => $contentContainer
+            ]); ?>
+        </div>
+
+        <?= Html::hiddenInput("containerGuid", $contentContainer->guid); ?>
+        <?= Html::hiddenInput("containerClass", get_class($contentContainer)); ?>
+
+        <ul id="contentFormError"></ul>
+
+        <div class="contentForm_options">
+            <hr>
+            <div class="btn_container">
+                <?= Button::info($submitButtonText)->action('submit')->id('post_submit_button')->submit() ?>
+
+                <?php
+                $uploadButton = UploadButton::widget([
+                    'id' => 'contentFormFiles',
+                    'tooltip' => Yii::t('ContentModule.base', 'Attach Files'),
+                    'progress' => '#contentFormFiles_progress',
+                    'preview' => '#contentFormFiles_preview',
+                    'dropZone' => '#contentFormBody',
+                    'max' => Yii::$app->getModule('content')->maxAttachedFiles
+                ]);
+                ?>
+                <?= FileHandlerButtonDropdown::widget(['primaryButton' => $uploadButton, 'handlers' => $fileHandlers, 'cssButtonClass' => 'btn-default']); ?>
+
+                <!-- public checkbox -->
+                <?= Html::checkbox("visibility", "", ['id' => 'contentForm_visibility', 'class' => 'contentForm hidden', 'aria-hidden' => 'true', 'title' => Yii::t('ContentModule.base', 'Content visibility') ]); ?>
+
+                <!-- content sharing -->
+                <div class="pull-right">
+
+                    <span class="label label-info label-public hidden"><?= Yii::t('ContentModule.base', 'Public'); ?></span>
+
+                    <ul class="nav nav-pills preferences" style="right: 0; top: 5px;">
+                        <li class="dropdown">
+                            <a class="dropdown-toggle" style="padding: 5px 10px;" data-toggle="dropdown" href="#" aria-label="<?= Yii::t('base', 'Toggle post menu'); ?>" aria-haspopup="true">
+                                <?= Icon::get('cogs')?>
+                            </a>
+                            <ul class="dropdown-menu pull-right">
+                                <li>
+                                    <?= Link::withAction(Yii::t('ContentModule.base', 'Notify members'), 'notifyUser')->icon('bell')?>
+                                </li>
+                                <?php if(TopicPicker::showTopicPicker($contentContainer)) : ?>
+                                    <li>
+                                        <?= Link::withAction(Yii::t('ContentModule.base', 'Topics'), 'setTopics')->icon(Yii::$app->getModule('topic')->icon) ?>
+                                    </li>
+                                <?php endif; ?>
+                                <?php if ($canSwitchVisibility): ?>
+                                    <li>
+                                        <?= Link::withAction(Yii::t('ContentModule.base', 'Change to "Public"'), 'changeVisibility')
+                                            ->id('contentForm_visibility_entry')->icon('unlock') ?>
+                                    </li>
+                                <?php endif; ?>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <?= UploadProgress::widget(['id' => 'contentFormFiles_progress']) ?>
+            <?= FilePreview::widget(['id' => 'contentFormFiles_preview', 'edit' => true, 'options' => ['style' => 'margin-top:10px;']]); ?>
+
+        </div>
+        <!-- /contentForm_Options -->
+        <?= Html::endForm(); ?>
+    </div>
+    <!-- /panel body -->
+</div> <!-- /panel -->
+

--- a/Smart Village App/views/content/widgets/wallCreateContentForm.php
+++ b/Smart Village App/views/content/widgets/wallCreateContentForm.php
@@ -36,7 +36,7 @@ $pickerUrl = ($contentContainer instanceof Space) ? $contentContainer->createUrl
 
 ?>
 
-<div class="panel panel-default clearfix" style="display:none;">
+<div class="panel panel-default clearfix" id="post_section">
     <div class="panel-body" id="contentFormBody" style="display:none;" data-action-component="content.form.CreateForm" >
         <?= Html::beginForm($submitUrl, 'POST'); ?>
 
@@ -126,4 +126,9 @@ $pickerUrl = ($contentContainer instanceof Space) ? $contentContainer->createUrl
     </div>
     <!-- /panel body -->
 </div> <!-- /panel -->
+
+<script>
+    let element = document.getElementById("post_section");
+    element.remove();
+</script>
 

--- a/Smart Village App/views/stream/widgets/wallStreamFilterNavigation.php
+++ b/Smart Village App/views/stream/widgets/wallStreamFilterNavigation.php
@@ -42,8 +42,7 @@ $rightPanelBlocks = isset($panels[WallStreamFilterNavigation::PANEL_POSITION_RIG
 
 <?= Html::endTag('div') ?>
 
-<style>
-    #wall-stream-filter-nav{
-        display:none !important;
-    }
-</style>
+<script>
+    let filterRemove = document.getElementById("wall-stream-filter-nav");
+    filterRemove.remove();
+</script>

--- a/Smart Village App/views/stream/widgets/wallStreamFilterNavigation.php
+++ b/Smart Village App/views/stream/widgets/wallStreamFilterNavigation.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2018 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ *
+ */
+
+use humhub\modules\stream\widgets\WallStreamFilterNavigation;
+use humhub\modules\ui\filter\widgets\FilterPanel;
+use humhub\widgets\Button;
+use yii\helpers\Html;
+
+/* @var $this \humhub\modules\ui\view\components\View */
+/* @var $panels [] */
+/* @var $options [] */
+
+$leftPanelBlocks = isset($panels[WallStreamFilterNavigation::PANEL_POSITION_LEFT]) ? $panels[WallStreamFilterNavigation::PANEL_POSITION_LEFT] : null;
+$centerPanelBlocks = isset($panels[WallStreamFilterNavigation::PANEL_POSITION_CENTER]) ? $panels[WallStreamFilterNavigation::PANEL_POSITION_CENTER] : null;
+$rightPanelBlocks = isset($panels[WallStreamFilterNavigation::PANEL_POSITION_RIGHT]) ? $panels[WallStreamFilterNavigation::PANEL_POSITION_RIGHT] : null;
+
+?>
+
+<?= Html::beginTag('div', $options) ?>
+
+<div class="wall-stream-filter-root nav-tabs">
+    <div class="wall-stream-filter-head clearfix">
+        <div class="wall-stream-filter-bar"></div>
+        <?= Button::asLink(Yii::t('ContentModule.base', 'Filter') . '<b class="caret"></b>')
+            ->cssClass('wall-stream-filter-toggle')->icon('fa-filter')->sm()->style('pa') ?>
+    </div>
+    <div class="wall-stream-filter-body" style="display:none">
+        <div class="filter-root">
+            <div class="row">
+                <?= FilterPanel::widget(['blocks' => $leftPanelBlocks, 'span' => count($panels)])?>
+                <?= FilterPanel::widget(['blocks' => $centerPanelBlocks, 'span' => count($panels)])?>
+                <?= FilterPanel::widget(['blocks' => $rightPanelBlocks, 'span' => count($panels)])?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?= Html::endTag('div') ?>
+
+<style>
+    #wall-stream-filter-nav{
+        display:none !important;
+    }
+</style>


### PR DESCRIPTION
There is a stream section in user's profile where you can create any post so, we hide that post section in user's profile stream.

**To hide post section. just adding css display property (display:none)**

![image](https://user-images.githubusercontent.com/103625795/178254200-03225bec-f818-4b93-a4e0-1aee4d0c6c9d.png)

**To hide filter section, take id of filter and add again css display property.**

![image](https://user-images.githubusercontent.com/103625795/178254436-df43013a-43ed-4e0b-82ae-34b954128bb8.png)



#3 