### PR TITLE
Hide and "decline" and "maybe" in admin form for calendar config #7

### DIFF
--- a/Smart Village App/views/calendar/common/_settings_participation.php
+++ b/Smart Village App/views/calendar/common/_settings_participation.php
@@ -1,0 +1,31 @@
+<?php
+
+use humhub\components\View;
+use humhub\modules\calendar\models\forms\CalendarEntryForm;
+use humhub\modules\calendar\models\participation\ParticipationSettings;
+use humhub\widgets\Button;
+
+/* @var $this View */
+/* @var $participationSettings ParticipationSettings */
+
+$helpBlock = $participationSettings->isGlobal()
+    ? Yii::t('CalendarModule.config', 'Here you can configure default settings for new calendar events. These settings can be overwritten on space/profile level.')
+    : Yii::t('CalendarModule.config', 'Here you can configure default settings for new calendar events.') ;
+
+?>
+
+<div class="panel-body" data-ui-widget="calendar.Form">
+    <h4>
+        <?= Yii::t('CalendarModule.config', 'Default participation settings'); ?>
+        <?php if ($participationSettings->showResetButton()) : ?>
+            <?= Button::defaultType(Yii::t('CalendarModule.config', 'Reset'))
+                ->action('client.pjax.post', $participationSettings->getResetButtonUrl())->link()->right()->sm()?>
+        <?php endif; ?>
+    </h4>
+
+    <div class="help-block">
+        <?= $helpBlock ?>
+    </div>
+
+    <?= $form->field($participationSettings, 'participation_mode')->dropDownList(CalendarEntryForm::getParticipationModeItems(), ['data-action-change' => 'changeParticipationMode']) ?>
+</div>


### PR DESCRIPTION
We hide "decline" and "maybe" checkboxes in admin form for calendar config.

Note : first uncheck both deline and maybe option. becuse value of these checboxes store in db

![image](https://user-images.githubusercontent.com/103625795/178268132-79e39e90-ae6f-4c3d-a27c-d724aa4df438.png)

In database
![image](https://user-images.githubusercontent.com/103625795/178268408-f2737f91-a5a8-4efb-8a04-d98472df391b.png)


If the value of these checbox is 1 (checked) they will show in calendar even't overview.

![image](https://user-images.githubusercontent.com/103625795/178268705-0982a370-3b01-4ef3-b790-494b70bb0d65.png)

**You can uncheck "decline" and "maybe" value  from any theme** 

#7 

 